### PR TITLE
fix: shell syntax error, port mismatch, stale names, and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a scaffold to build applications on the Hyli network using Risc0 contracts.
 
-For step-by-step instructions, [follow our quickstart](https://docs.hyli.org/quickstart/run.md).
+For step-by-step instructions, [follow our quickstart](https://docs.hyli.org/quickstart/).
 
 ## Architecture
 
@@ -39,7 +39,7 @@ From the root of this repository:
 
 ```bash
 # Export devnet env vars first, so that server can connect to your local devnet
-source <(hy devnet env)>
+source <(hy devnet env)
 cargo run -p server
 ```
 

--- a/contracts/contract1/src/lib.rs
+++ b/contracts/contract1/src/lib.rs
@@ -35,7 +35,7 @@ impl sdk::ZkContract for Contract1 {
 
     /// In this example, we serialize the full state on-chain.
     fn commit(&self) -> sdk::StateCommitment {
-        sdk::StateCommitment(self.as_bytes().expect("Failed to encsode Balances"))
+        sdk::StateCommitment(self.as_bytes().expect("Failed to encode Contract1 state"))
     }
 }
 
@@ -72,7 +72,7 @@ impl Contract1Action {
 impl From<sdk::StateCommitment> for Contract1 {
     fn from(state: sdk::StateCommitment) -> Self {
         borsh::from_slice(&state.0)
-            .map_err(|_| "Could not decode hyllar state".to_string())
+            .map_err(|_| "Could not decode Contract1 state".to_string())
             .unwrap()
     }
 }

--- a/front/index.html
+++ b/front/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Hyli App Scaffold</title>
   </head>
   <body>
     <div id="root"></div>

--- a/front/package.json
+++ b/front/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blackjack-win95",
+  "name": "hyli-app-scaffold",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -211,7 +211,7 @@ function App() {
         applicationWsUrl: import.meta.env.VITE_WALLET_WS_URL,
       }}
       sessionKeyConfig={{
-        duration: 24 * 60 * 60 * 1000, // Session key duration in ms (default: 72h)
+        duration: 24 * 60 * 60 * 1000, // Session key duration in ms (24h)
         whitelist: ["contract1"], // Required: contracts allowed for session key
       }}
     >

--- a/server/src/conf_defaults.toml
+++ b/server/src/conf_defaults.toml
@@ -4,7 +4,7 @@ log_format = "full"
 data_directory = "data"
 da_read_from = "127.0.0.1:4141"
 
-rest_server_port = 9002
+rest_server_port = 9003
 rest_server_max_body_size = 10_485_760 # 10 MB
 node_url = "http://localhost:4321"
 indexer_url = "http://localhost:4321"


### PR DESCRIPTION
## Summary

Fixes several bugs and issues that break the out-of-the-box developer experience.

### Critical fixes
- **Shell syntax error in README**: `source <(hy devnet env)>` has an extra `>` that causes a bash error — fixed to `source <(hy devnet env)`
- **Port mismatch**: Frontend `.env` expects server at `localhost:9003` but `conf_defaults.toml` starts server on port `9002` — aligned to `9003` so the app works out-of-the-box
- **Wrong package name**: `front/package.json` was named `"blackjack-win95"` (leftover from a different project) — renamed to `"hyli-app-scaffold"`

### Code fixes
- `"Failed to encsode Balances"` → `"Failed to encode Contract1 state"` (typo + stale name)
- `"Could not decode hyllar state"` → `"Could not decode Contract1 state"` (stale reference to different contract)

### Minor fixes
- Stale quickstart link `quickstart/run.md` → `quickstart/` (MkDocs sites don't use .md in URLs)
- Generic HTML title `"Vite + React + TS"` → `"Hyli App Scaffold"`
- Misleading comment said session key duration is "72h" but code sets 24h — fixed comment to say "24h"

## Test plan
- [ ] Run `source <(hy devnet env)` and verify it works without syntax error
- [ ] Start server with `cargo run -p server` and verify it listens on port 9003
- [ ] Start frontend and verify it connects to server successfully
- [ ] Verify `npm install` succeeds with the new package name

